### PR TITLE
Add `isBlank`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -340,6 +340,8 @@ export const isEmptyRepoRoot = (): boolean => isRepoHome() && !exists('link[rel=
 
 export const isEmptyRepo = (): boolean => exists('[aria-label="Cannot fork because repository is empty."]');
 
+export const isBlank = (): boolean => exists('main .blankslate');
+
 export const isRepoTaxonomyConversationList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^labels\/.+|^milestones\/\d+(?!\/edit)/.test(getRepo(url)?.path!);
 collect.set('isRepoTaxonomyConversationList', [
 	'https://github.com/sindresorhus/refined-github/labels/bug',


### PR DESCRIPTION
Resolves #100 

Example URLs:
- [Empty milestone](https://github.com/fish-shell/fish-shell/milestone/30)
- [Repo taken down by GitHub](https://github.com/fastai/fastmac)
- [Deleted issue](https://github.com/refined-github/refined-github/issues/2821)