### PR TITLE
Breaking: Use import `assert {type: 'json'}`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import reservedNames from 'github-reserved-names/reserved-names.json';
+import reservedNames from 'github-reserved-names/reserved-names.json' assert {type: "json"};
 import collect from './collector.js';
 
 const exists = (selector: string) => Boolean(document.querySelector(selector));


### PR DESCRIPTION
Breaking change to keep track of. We can finish and release this in the next breaking release. It would let us avoid bundling the dependency.

We'll still need a build step to drop the tests though.

It requires Node 17.1