### PR TITLE
Add `isPrivateUserProfile`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -555,6 +555,8 @@ collect.set('isProfile', [
 
 export const isUserProfile = (): boolean => isProfile() && !isOrganizationProfile();
 
+export const isPrivateUserProfile = (): boolean => isUserProfile() && !exists('.user-following-container');
+
 export const isUserProfileMainTab = (): boolean =>
 	isUserProfile()
 	&& !new URLSearchParams(location.search).has('tab');


### PR DESCRIPTION
To be used in Refined GitHub.

There are several ways to tell if a user profile is private, here we are looking at whether the (un)follow button exist or not.