### PR TITLE
Ensure `is[Status]PR` only matches PRs and not issues

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -264,12 +264,11 @@ addTests('isQuickPR', [
 	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1',
 ]);
 
-export const isDraftPR = (): boolean => exists('#partial-discussion-header [title="Status: Draft"]');
-export const isOpenPR = (): boolean => exists('#partial-discussion-header [title="Status: Open"], #partial-discussion-header [title="Status: Draft"]');
-export const isMergedPR = (): boolean => exists('#partial-discussion-header [title="Status: Merged"]');
-export const isClosedConversation = (): boolean => exists('#partial-discussion-header :is([title="Status: Closed"], [title="Status: Merged"], [title="Status: Closed as not planned"])');
-/** @deprecated Use isClosedConversation */
-export const isClosedPR = isClosedConversation;
+export const isDraftPR = (): boolean => exists('#partial-discussion-header .octicon-git-pull-request-draft');
+export const isOpenPR = (): boolean => exists('#partial-discussion-header :is(.octicon-git-pull-request, .octicon-git-pull-request-draft)');
+export const isMergedPR = (): boolean => exists('#partial-discussion-header .octicon-git-merge');
+export const isClosedPR = (): boolean => exists('#partial-discussion-header :is(.octicon-git-pull-request-closed, .octicon-git-merge)');
+export const isClosedIssue = (): boolean => exists('#partial-discussion-header :is(.octicon-issue-closed, .octicon-skip)');
 
 export const isReleases = (url: URL | HTMLAnchorElement | Location = location): boolean => getRepo(url)?.path === 'releases';
 addTests('isReleases', [


### PR DESCRIPTION
Reverts this PR and instead ensures that `isClosedPR`, `isOpenPR`, etc only match PRs:

- https://github.com/refined-github/github-url-detection/pull/120