### PR TITLE
Add `isPublicRepo`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -349,6 +349,8 @@ export const isEmptyRepoRoot = (): boolean => isRepoHome() && !exists('link[rel=
 
 export const isEmptyRepo = (): boolean => exists('[aria-label="Cannot fork because repository is empty."]');
 
+export const isPublicRepo = (): boolean => Boolean(isRepo() && $('#repository-container-header .Label')!.textContent!.startsWith('Public'));
+
 export const isArchivedRepo = (): boolean => Boolean(isRepo() && $('#repository-container-header .Label')!.textContent!.endsWith('archive'));
 
 export const isBlank = (): boolean => exists('main .blankslate');


### PR DESCRIPTION
To be used in Refined GitHub (I think there may be several features could benefit from this)

I wonder why we didn't have this (until now)

Test URL: here