### PR TITLE
Add `isTemplateRepo`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -351,6 +351,8 @@ export const isEmptyRepo = (): boolean => exists('[aria-label="Cannot fork becau
 
 export const isArchivedRepo = (): boolean => Boolean(isRepo() && $('#repository-container-header .Label')!.textContent!.endsWith('archive'));
 
+export const isTemplateRepo = (): boolean => exists('#repository-container-header .octicon-repo-template');
+
 export const isBlank = (): boolean => exists('main .blankslate');
 
 export const isRepoTaxonomyIssueOrPRList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^labels\/.+|^milestones\/\d+(?!\/edit)/.test(getRepo(url)?.path!);


### PR DESCRIPTION
Not needed for _now_, but I think we might as well add this.

Unlike existing `isArchivedRepo` and pending [`isPublicRepo`](https://github.com/refined-github/github-url-detection/pull/140), we can't check a template repo against its label because:

- On [a public template repo](https://github.com/othneildrew/Best-README-Template): label shows as "Public template"
- On [a public **archived** template repo](https://github.com/readthedocs/template): label shows as "Public archive"

So we check the repo icon like the [`repo-avatars`](https://github.com/refined-github/refined-github/blob/4e2302915de073771905df8daab615cf30d39eba/source/features/repo-avatars.tsx#L11) feature.