### PR TITLE
Fix type publishing

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -10,7 +10,7 @@ name: ESM
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
   push:
     branches:
       - master

--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -10,7 +10,7 @@ name: ESM
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
       - master
@@ -73,6 +73,15 @@ jobs:
       - run: echo "${{ env.IMPORT_TEXT }} '${{ env.NPM_MODULE_NAME }}'" > index.js
       - run: npm install ./artifact
       - run: npx esbuild --bundle index.js
+  TypeScript:
+    runs-on: ubuntu-latest
+    needs: Pack
+    steps:
+      - uses: actions/download-artifact@v3
+      - run: npm install ./artifact
+      - run: echo "${{ env.IMPORT_TEXT }} '${{ env.NPM_MODULE_NAME }}'" > index.ts
+      - run: tsc index.ts
+      - run: cat index.js
   Node:
     runs-on: ubuntu-latest
     needs: Pack

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"demo:build": "vite build demo --config demo/vite.config.js",
 		"demo:test": "svelte-check",
 		"demo:watch": "vite serve demo --config demo/vite.config.js",
-		"prepack": "vite build",
+		"prepack": "npm run build",
 		"test": "run-p build ava xo",
 		"watch": "run-p watch:typescript demo:watch # vite watch doesn’t generate the lib, so just use the demo",
 		"watch:typescript": "tsc --watch --noEmit",


### PR DESCRIPTION
`vite build` does not build the types (and nukes `distribution` folder before building, so order matters 😅), so the published module is missing types:

https://github.com/refined-github/github-url-detection/runs/7555734222?check_suite_focus=true#step:7:19