### PR TITLE
Fix `isPrivateUserProfile` false positive on `isOwnUserProfile`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -585,7 +585,7 @@ addTests('isGistProfile', [
 
 export const isUserProfile = (): boolean => isProfile() && !isOrganizationProfile();
 
-export const isPrivateUserProfile = (): boolean => isUserProfile() && !exists('.user-following-container');
+export const isPrivateUserProfile = (): boolean => isUserProfile() && !exists('.UnderlineNav-item[href$="tab=stars"]');
 
 export const isUserProfileMainTab = (): boolean =>
 	isUserProfile()


### PR DESCRIPTION
I just remembered, you can't follow yourself 🥲 so this time we are checking if the Stars tab is there.

I also tested the feature myself and learned it doesn't affect yourself (apparently). 

Test URL:

- A private user profile: https://github.com/Centril
- A public user profile, with no stars (to demonstrate the Stars tab is still shown for them): https://github.com/examplew