### PR TITLE
Earlier detection for `isPublicRepo`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -362,7 +362,7 @@ export const isEmptyRepoRoot = (): boolean => isRepoHome() && !exists('link[rel=
 
 export const isEmptyRepo = (): boolean => exists('[aria-label="Cannot fork because repository is empty."]');
 
-export const isPublicRepo = (): boolean => Boolean(isRepo() && $('#repository-container-header .Label')!.textContent!.startsWith('Public'));
+export const isPublicRepo = (): boolean => Boolean(isRepo() && exists('meta[name="octolytics-dimension-repository_public"][content="true"]'));
 
 export const isArchivedRepo = (): boolean => Boolean(isRepo() && $('#repository-container-header .Label')!.textContent!.endsWith('archive'));
 

--- a/index.ts
+++ b/index.ts
@@ -362,7 +362,7 @@ export const isEmptyRepoRoot = (): boolean => isRepoHome() && !exists('link[rel=
 
 export const isEmptyRepo = (): boolean => exists('[aria-label="Cannot fork because repository is empty."]');
 
-export const isPublicRepo = (): boolean => Boolean(isRepo() && exists('meta[name="octolytics-dimension-repository_public"][content="true"]'));
+export const isPublicRepo = (): boolean => exists('meta[name="octolytics-dimension-repository_public"][content="true"]');
 
 export const isArchivedRepo = (): boolean => Boolean(isRepo() && $('#repository-container-header .Label')!.textContent!.endsWith('archive'));
 


### PR DESCRIPTION
**Description**

- The changes update the `isPublicRepo` method to use `octolytics-dimension-repository_public` meta tag.
- Fixes [#151](https://github.com/refined-github/github-url-detection/issues/151).

**Tests with refined-github extension** 

- Previous implementation produced an minor issuse.
![minorBugWithIsPublicRepo](https://user-images.githubusercontent.com/118078892/218256561-679bd029-a053-498a-b2d4-94bd2632f398.PNG)

- **After changes**, test with public repo
![testPublicRepo](https://user-images.githubusercontent.com/118078892/218256621-5cb2dd72-a268-4eda-b025-86ac8a3933dd.PNG)

- test with a private repo 
![testPrivateRepo](https://user-images.githubusercontent.com/118078892/218256672-e3cea8c6-d77a-4fc0-a50d-be99a1330f06.PNG)

 