### PR TITLE
Allow permalinks in demo

### DIFF
--- a/demo/App.svelte
+++ b/demo/App.svelte
@@ -4,22 +4,23 @@
 	import * as urlDetection from '../index';
 	import { getAllUrls } from '../collector';
 
-	const urlParameter = new URLSearchParams(location.search);
 	const defaultUrl = 'https://github.com/refined-github/github-url-detection';
-	// Parse partial URL in the URL parameter so that it's shown as full URL in the input
-	let url = parseUrl(urlParameter.get('url')).href || '';
+	const urlParameter = new URLSearchParams(location.search);
+	const parsedUrlParameter = parseUrl(urlParameter.get('url'), 'https://github.com').href;
+	// Parse partial URL in the parameter so that it's shown as full URL in the field
+	let urlField = parsedUrlParameter || '';
 
 	const allUrls = [...getAllUrls()].sort();
 
 	let parsedUrl;
 	// Do not use ?? because it should work on empty strings
-	$: parsedUrl = parseUrl(url || defaultUrl);
+	$: parsedUrl = parseUrl(urlField || defaultUrl);
 
 	let detections = [];
 	$: {
 		if (parsedUrl) {
-			if (url) {
-				urlParameter.set('url', url.replace('https://github.com', ''));
+			if (urlField) {
+				urlParameter.set('url', urlField.replace('https://github.com', ''));
 				history.replaceState(null, '', `?${urlParameter}`);
 			} else {
 				history.replaceState(null, '', location.pathname);
@@ -80,7 +81,7 @@
 	<span>URL:</span>
 	<input
 		type="search"
-		bind:value={url}
+		bind:value={urlField}
 		placeholder={defaultUrl}
 		autocomplete="off"
 		autocorrect="off"

--- a/demo/App.svelte
+++ b/demo/App.svelte
@@ -1,6 +1,7 @@
 <script>
+	const urlParameter = new URLSearchParams(location.search).get('url')
 	const defaultUrl = 'https://github.com/refined-github/github-url-detection';
-	export let url = '';
+	export let url = urlParameter ?? '';
 	import * as urlDetection from '../index';
 	import { getAllUrls } from '../collector';
 
@@ -9,6 +10,7 @@
 	let isUrlValid;
 	$: {
 		try {
+			// Do not use ?? because it should work on empty strings
 			new URL(url || defaultUrl);
 			isUrlValid = true;
 		} catch {

--- a/demo/parse-url.js
+++ b/demo/parse-url.js
@@ -1,4 +1,8 @@
 export default function parseUrl(url, origin) {
+	if (!url) {
+		return false;
+	}
+
 	try {
 		return new URL(url, origin);
 	} catch {

--- a/demo/parse-url.js
+++ b/demo/parse-url.js
@@ -1,0 +1,7 @@
+export default function parseUrl(url) {
+	try {
+		return new URL(url, 'https://github.com');
+	} catch {
+		return false;
+	}
+}

--- a/demo/parse-url.js
+++ b/demo/parse-url.js
@@ -1,6 +1,6 @@
-export default function parseUrl(url) {
+export default function parseUrl(url, origin) {
 	try {
-		return new URL(url, 'https://github.com');
+		return new URL(url, origin);
 	} catch {
 		return false;
 	}


### PR DESCRIPTION
- Closes #150

### Behavior

- Dynamically links the URL field to the `url` parameter
	- https://deploy-preview-163--preview-for-github-url-detection.netlify.app/?url=http%3A%2F%2Fgist.github.com
- When the field is empty, the `url` parameter is dropped and the hardcoded default is picked up
	- https://deploy-preview-163--preview-for-github-url-detection.netlify.app/
- Drops the standard origin from the parameter to keep the URL short (no `https://github.com`)
	- https://deploy-preview-163--preview-for-github-url-detection.netlify.app/?url=%2Ffregante
- Only shows and accepts full URLs in the field
	<img width="201" alt="Screenshot 5" src="https://user-images.githubusercontent.com/1402241/230764740-0b2a4d1c-13a1-4e23-873e-ecbba584addf.png">

