### PR TITLE
Add `isProfileRepoList`

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: https://registry.npmjs.org
       - run: npm ci || npm install
       - uses: fregante/setup-git-user@v2
       - name: Create version

--- a/index.ts
+++ b/index.ts
@@ -632,8 +632,9 @@ addTests('isUserProfileFollowingTab', [
 export const isProfileRepos = (url: URL | HTMLAnchorElement | Location = location): boolean =>
 	isUserProfileRepoTab(url) || getOrg(url)?.path === 'repositories';
 addTests('isProfileRepos', [
-	'https://github.com/fregante?tab=stars',
-	'https://github.com/fregante?direction=desc&sort=updated&tab=stars',
+	'https://github.com/fregante?tab=repositories',
+	'https://github.com/fregante?tab=repositories&type=source',
+	'https://github.com/fregante?tab=repositories&q=&type=source&language=css&sort=',
 	'https://github.com/orgs/refined-github/repositories',
 	'https://github.com/orgs/refined-github/repositories?q=&type=private&language=&sort=',
 ]);

--- a/index.ts
+++ b/index.ts
@@ -629,6 +629,15 @@ addTests('isUserProfileFollowingTab', [
 	'https://github.com/sindresorhus?tab=following',
 ]);
 
+export const isProfileRepos = (url: URL | HTMLAnchorElement | Location = location): boolean =>
+	isUserProfileRepoTab(url) || getOrg(url)?.path === 'repositories';
+addTests('isProfileRepos', [
+	'https://github.com/fregante?tab=stars',
+	'https://github.com/fregante?direction=desc&sort=updated&tab=stars',
+	'https://github.com/orgs/refined-github/repositories',
+	'https://github.com/orgs/refined-github/repositories?q=&type=private&language=&sort=',
+]);
+
 addTests('hasComments', combinedTestOnly);
 export const hasComments = (url: URL | HTMLAnchorElement | Location = location): boolean =>
 	isPR(url)

--- a/index.ts
+++ b/index.ts
@@ -629,9 +629,9 @@ addTests('isUserProfileFollowingTab', [
 	'https://github.com/sindresorhus?tab=following',
 ]);
 
-export const isProfileRepos = (url: URL | HTMLAnchorElement | Location = location): boolean =>
+export const isProfileRepoList = (url: URL | HTMLAnchorElement | Location = location): boolean =>
 	isUserProfileRepoTab(url) || getOrg(url)?.path === 'repositories';
-addTests('isProfileRepos', [
+addTests('isProfileRepoList', [
 	'https://github.com/fregante?tab=repositories',
 	'https://github.com/fregante?tab=repositories&type=source',
 	'https://github.com/fregante?tab=repositories&q=&type=source&language=css&sort=',

--- a/test.ts
+++ b/test.ts
@@ -38,7 +38,7 @@ for (const [detectName, detect] of Object.entries(pageDetect)) {
 					Is this URL \`${detectName}\`?
 						${url.replace('https://github.com', '')}
 
-					• Yes? The \`${detectName}\` test is wrong and should be fixed.
+					• Yes? The \`${detectName}\` detection is wrong and should be fixed.
 					• No? Remove it from its \`collect.set()\` array.
 				`),
 			);
@@ -60,7 +60,7 @@ for (const [detectName, detect] of Object.entries(pageDetect)) {
 							${url.replace('https://github.com', '')}
 
 						• Yes? Add it to the \`collect.set()\` array.
-						• No? The \`${detectName}\` test is wrong and should be fixed.
+						• No? The \`${detectName}\` detection is wrong and should be fixed.
 					`),
 				);
 			});


### PR DESCRIPTION
We have these detections:

- isUserProfileMainTab
- isUserProfileRepoTab
- isUserProfileStarsTab
- isUserProfileFollowersTab
- isUserProfileFollowingTab

Which nowadays are unnecessarily specific since repository lists are similar in DOM, and will only get more similar (HOPEFULLY):

- https://github.com/fregante?tab=repositories
- https://github.com/orgs/refined-github/repositories

For the same reason I'm not adding an org-specific detection.

I haven't merged this yet to make sure I choose the right name here. I think `*Tab` was the wrong choice because:

- we don't have ~~`isRepoSettingsTab`~~ but `isRepoSettings` 
- etc

We can rename those separately, potentially deprecate `isUserProfileRepoTab` completely.