### PR TITLE
fix(is404): add condition for not found page when logged in

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ addTests('__urls_that_dont_match__', [
 	'https://github.com/sindresorhus/refined-github/issues/templates/edit',
 ]);
 
-export const is404 = (): boolean => document.title.startsWith('Page not found · GitHub'); // #98
+export const is404 = (): boolean => document.title.startsWith('Page not found · GitHub') || document.title.startsWith('File not found · GitHub'); // #98
 
 export const is500 = (): boolean => document.title === 'Server Error · GitHub' || document.title === 'Unicorn! · GitHub' || document.title === '504 Gateway Time-out';
 


### PR DESCRIPTION
#### Overview

When logged in and in the file tree, GitHub changes the page title to `File not found` if the requested file/folder is missing.

However, when logged out or an issue/pr is not found, the page title is changed to `Page not found`.

This PR updates the `is404` function to reflect the above change.

#### Test URLs

- https://github.com/refined-github/refined-github/blob/main/source/features/a-horse-with-no-name.tsx
- https://github.com/refined-github/refined-github/blob/main/source/a-unicorn-with-no-name/
- https://github.com/refined-github/refined-github/issues/999999999999

> Merging this PR will be the first step in fixing https://github.com/refined-github/refined-github/blob/main/source/features/useful-not-found-page.tsx :)