### PR TITLE
Exclude special `search` URLs from `isRepoRoot` and `isRepoHome`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,6 @@ addTests('__urls_that_dont_match__', [
 	'https://github.com/sindresorhus/refined-github/issues/new',
 	'https://github.com/sindresorhus/refined-github/issues/new/choose',
 	'https://github.com/sindresorhus/refined-github/issues/templates/edit',
-	'https://github.com?search=1',
 	'https://github.com/orgs/community/discussions/new/choose',
 ]);
 
@@ -82,6 +81,7 @@ addTests('isDashboard', [
 	'https://github.com/?tab=followers', // Gotcha for `isUserProfileFollowersTab`
 	'https://github.com/?tab=following', // Gotcha for `isUserProfileFollowingTab`
 	'https://github.com/?tab=overview', // Gotcha for `isUserProfileMainTab`
+	'https://github.com?search=1', // Gotcha for `isRepoTree`
 ]);
 
 export const isEnterprise = (url: URL | HTMLAnchorElement | Location = location): boolean => url.hostname !== 'github.com' && url.hostname !== 'gist.github.com';

--- a/index.ts
+++ b/index.ts
@@ -490,17 +490,17 @@ export const isRepoTree = (url: URL | HTMLAnchorElement | Location = location): 
 addTests('isRepoTree', [
 	'isRepoRoot',
 	'isRepoTreeFileFinder',
-	'https://github.com/sindresorhus/refined-github/tree/master/distribution',
-	'https://github.com/sindresorhus/refined-github/tree/0.13.0/distribution',
-	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/distribution',
+	'https://github.com/sindresorhus/refined-github/tree/main/source',
+	'https://github.com/sindresorhus/refined-github/tree/0.13.0/extension',
+	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/extension',
 ]);
 
 export const isRepoTreeFileFinder = (url: URL | HTMLAnchorElement | Location = location): boolean => new URLSearchParams(url.search).get('search') === '1';
 addTests('isRepoTreeFileFinder', [
 	'https://github.com/sindresorhus/refined-github?search=1',
-	'https://github.com/sindresorhus/refined-github/tree/master/distribution?search=1',
-	'https://github.com/sindresorhus/refined-github/tree/0.13.0/distribution?search=1',
-	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/distribution?search=1',
+	'https://github.com/sindresorhus/refined-github/tree/main/source?search=1',
+	'https://github.com/sindresorhus/refined-github/tree/0.13.0/extension?search=1',
+	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/extension?search=1',
 ]);
 
 export const isRepoWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('wiki'));

--- a/index.ts
+++ b/index.ts
@@ -405,7 +405,8 @@ addTests('isRepoIssueList', [
 	'https://github.com/sindresorhus/refined-github/labels/%3Adollar%3A%20Funded%20on%20Issuehunt',
 ]);
 
-export const isRepoHome = (url: URL | HTMLAnchorElement | Location = location): boolean => getRepo(url)?.path === '';
+export const isRepoHome = (url: URL | HTMLAnchorElement | Location = location): boolean => getRepo(url)?.path === ''
+	&& !isRepoTreeFileFinder(url);
 addTests('isRepoHome', [
 	// Some tests are here only as "gotchas" for other tests that may misidentify their pages
 	'https://github.com/sindresorhus/refined-github',
@@ -422,6 +423,10 @@ export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean =>
 	const repository = getRepo(url ?? location);
 
 	if (!repository) {
+		return false;
+	}
+
+	if (isRepoTreeFileFinder(url ?? location)) {
 		return false;
 	}
 
@@ -479,12 +484,23 @@ addTests('isUserSettings', [
 	'isRepliesSettings',
 ]);
 
-export const isRepoTree = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoRoot(url) || Boolean(getRepo(url)?.path.startsWith('tree/'));
+export const isRepoTree = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoRoot(url)
+	|| Boolean(getRepo(url)?.path.startsWith('tree/'))
+	|| isRepoTreeFileFinder(url);
 addTests('isRepoTree', [
 	'isRepoRoot',
+	'isRepoTreeFileFinder',
 	'https://github.com/sindresorhus/refined-github/tree/master/distribution',
 	'https://github.com/sindresorhus/refined-github/tree/0.13.0/distribution',
 	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/distribution',
+]);
+
+export const isRepoTreeFileFinder = (url: URL | HTMLAnchorElement | Location = location): boolean => new URLSearchParams(url.search).get('search') === '1';
+addTests('isRepoTreeFileFinder', [
+	'https://github.com/sindresorhus/refined-github?search=1',
+	'https://github.com/sindresorhus/refined-github/tree/master/distribution?search=1',
+	'https://github.com/sindresorhus/refined-github/tree/0.13.0/distribution?search=1',
+	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/distribution?search=1',
 ]);
 
 export const isRepoWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('wiki'));

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ addTests('__urls_that_dont_match__', [
 	'https://github.com/sindresorhus/refined-github/issues/new',
 	'https://github.com/sindresorhus/refined-github/issues/new/choose',
 	'https://github.com/sindresorhus/refined-github/issues/templates/edit',
+	'https://github.com/sindresorhus/refined-github?search=1',
 ]);
 
 export const is404 = (): boolean => /^(Page|File) not found · GitHub/.test(document.title); // #98; When logged out, it starts with "File"
@@ -405,8 +406,10 @@ addTests('isRepoIssueList', [
 	'https://github.com/sindresorhus/refined-github/labels/%3Adollar%3A%20Funded%20on%20Issuehunt',
 ]);
 
+const hasSearchParameter = (url: URL | HTMLAnchorElement | Location = location): boolean => new URLSearchParams(url.search).get('search') === '1';
+
 export const isRepoHome = (url: URL | HTMLAnchorElement | Location = location): boolean => getRepo(url)?.path === ''
-	&& !isRepoTreeFileFinder(url);
+	&& !hasSearchParameter(url);
 addTests('isRepoHome', [
 	// Some tests are here only as "gotchas" for other tests that may misidentify their pages
 	'https://github.com/sindresorhus/refined-github',
@@ -426,7 +429,7 @@ export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean =>
 		return false;
 	}
 
-	if (isRepoTreeFileFinder(url ?? location)) {
+	if (hasSearchParameter(url ?? location)) {
 		return false;
 	}
 
@@ -486,21 +489,12 @@ addTests('isUserSettings', [
 
 export const isRepoTree = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoRoot(url)
 	|| Boolean(getRepo(url)?.path.startsWith('tree/'))
-	|| isRepoTreeFileFinder(url);
+	|| hasSearchParameter(url);
 addTests('isRepoTree', [
 	'isRepoRoot',
-	'isRepoTreeFileFinder',
 	'https://github.com/sindresorhus/refined-github/tree/main/source',
 	'https://github.com/sindresorhus/refined-github/tree/0.13.0/extension',
 	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/extension',
-]);
-
-export const isRepoTreeFileFinder = (url: URL | HTMLAnchorElement | Location = location): boolean => new URLSearchParams(url.search).get('search') === '1';
-addTests('isRepoTreeFileFinder', [
-	'https://github.com/sindresorhus/refined-github?search=1',
-	'https://github.com/sindresorhus/refined-github/tree/main/source?search=1',
-	'https://github.com/sindresorhus/refined-github/tree/0.13.0/extension?search=1',
-	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/extension?search=1',
 ]);
 
 export const isRepoWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('wiki'));

--- a/index.ts
+++ b/index.ts
@@ -443,6 +443,7 @@ const _isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => {
 	return repository.path.startsWith('tree/') && document.title.startsWith(repository.nameWithOwner) && !document.title.endsWith(repository.nameWithOwner);
 };
 
+// `_isRepoRoot` logic depends on whether a URL was passed, so don't use a `url` default parameter
 export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => !hasSearchParameter(url ?? location) && _isRepoRoot(url);
 
 addTests('isRepoRoot', [

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ addTests('__urls_that_dont_match__', [
 	'https://github.com/sindresorhus/refined-github/issues/new',
 	'https://github.com/sindresorhus/refined-github/issues/new/choose',
 	'https://github.com/sindresorhus/refined-github/issues/templates/edit',
-	'https://github.com/sindresorhus/refined-github?search=1',
+	'https://github.com?search=1',
 ]);
 
 export const is404 = (): boolean => /^(Page|File) not found · GitHub/.test(document.title); // #98; When logged out, it starts with "File"

--- a/index.ts
+++ b/index.ts
@@ -406,7 +406,7 @@ addTests('isRepoIssueList', [
 	'https://github.com/sindresorhus/refined-github/labels/%3Adollar%3A%20Funded%20on%20Issuehunt',
 ]);
 
-const hasSearchParameter = (url: URL | HTMLAnchorElement | Location = location): boolean => new URLSearchParams(url.search).get('search') === '1';
+const hasSearchParameter = (url: URL | HTMLAnchorElement | Location): boolean => new URLSearchParams(url.search).get('search') === '1';
 
 export const isRepoHome = (url: URL | HTMLAnchorElement | Location = location): boolean => getRepo(url)?.path === ''
 	&& !hasSearchParameter(url);
@@ -426,10 +426,6 @@ const _isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => {
 	const repository = getRepo(url ?? location);
 
 	if (!repository) {
-		return false;
-	}
-
-	if (hasSearchParameter(url ?? location)) {
 		return false;
 	}
 

--- a/index.ts
+++ b/index.ts
@@ -443,7 +443,7 @@ const _isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => {
 	return repository.path.startsWith('tree/') && document.title.startsWith(repository.nameWithOwner) && !document.title.endsWith(repository.nameWithOwner);
 };
 
-export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => !hasSearchParameter(url) && _isRepoRoot(url);
+export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => !hasSearchParameter(url ?? location) && _isRepoRoot(url);
 
 addTests('isRepoRoot', [
 	'isRepoHome',
@@ -491,6 +491,7 @@ addTests('isRepoTree', [
 	'https://github.com/sindresorhus/refined-github/tree/main/source',
 	'https://github.com/sindresorhus/refined-github/tree/0.13.0/extension',
 	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/extension',
+	'https://github.com/sindresorhus/refined-github?search=1',
 ]);
 
 export const isRepoWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('wiki'));

--- a/index.ts
+++ b/index.ts
@@ -422,7 +422,7 @@ addTests('isRepoHome', [
 	'https://github.com/sindresorhus/refined-github?files=1',
 ]);
 
-export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => {
+const _isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => {
 	const repository = getRepo(url ?? location);
 
 	if (!repository) {
@@ -446,6 +446,8 @@ export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean =>
 	// If we're checking the current page, add support for branches with slashes // #15 #24
 	return repository.path.startsWith('tree/') && document.title.startsWith(repository.nameWithOwner) && !document.title.endsWith(repository.nameWithOwner);
 };
+
+export const isRepoRoot = (url?: URL | HTMLAnchorElement | Location): boolean => !hasSearchParameter(url) && _isRepoRoot(url);
 
 addTests('isRepoRoot', [
 	'isRepoHome',
@@ -487,9 +489,7 @@ addTests('isUserSettings', [
 	'isRepliesSettings',
 ]);
 
-export const isRepoTree = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoRoot(url)
-	|| Boolean(getRepo(url)?.path.startsWith('tree/'))
-	|| hasSearchParameter(url);
+export const isRepoTree = (url: URL | HTMLAnchorElement | Location = location): boolean => _isRepoRoot(url) || Boolean(getRepo(url)?.path.startsWith('tree/'));
 addTests('isRepoTree', [
 	'isRepoRoot',
 	'https://github.com/sindresorhus/refined-github/tree/main/source',


### PR DESCRIPTION
Fixes #173
