### PR TITLE
POC for JSDoc extraction

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -1,0 +1,16 @@
+import {Project} from 'ts-morph';
+
+const project = new Project({
+	tsConfigFilePath: 'tsconfig.json',
+});
+const testSourceFiles = project.getSourceFile('index.ts');
+for (const tag of testSourceFiles.getSymbol('isRepo').getExport('isRepo').getJsDocTags()) {
+	if (tag.getName() !== 'example') {
+		continue;
+	}
+
+	const contents = tag.getText().at(0).text;
+	if (contents.startsWith('http')) {
+		console.log(contents);
+	}
+}

--- a/index.ts
+++ b/index.ts
@@ -344,6 +344,10 @@ addTests('isEditingWikiPage', [
 export const hasWikiPageEditor = (url: URL | HTMLAnchorElement | Location = location): boolean => isEditingWikiPage(url) || isNewWikiPage(url);
 addTests('hasWikiPageEditor', combinedTestOnly);
 
+/**
+ * @example https://github.com/sindresorhus/refined-github/blame/master/package.json
+ * @example https://github.com/sindresorhus/notifications/
+ */
 export const isRepo = (url: URL | HTMLAnchorElement | Location = location): boolean => /^[^/]+\/[^/]+/.test(getCleanPathname(url))
 	&& !reservedNames.includes(url.pathname.split('/', 2)[1]!)
 	&& !isDashboard(url)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"strip-indent": "^4.0.0",
 				"svelte": "^4.1.2",
 				"svelte-check": "^3.4.6",
+				"ts-morph": "^19.0.0",
 				"typescript": "^5.1.6",
 				"vite": "^4.4.7",
 				"xo": "^0.55.0"
@@ -864,6 +865,57 @@
 				"@sveltejs/vite-plugin-svelte": "^2.2.0",
 				"svelte": "^3.54.0 || ^4.0.0",
 				"vite": "^4.0.0"
+			}
+		},
+		"node_modules/@ts-morph/common": {
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
+			"integrity": "sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==",
+			"dev": true,
+			"dependencies": {
+				"fast-glob": "^3.2.12",
+				"minimatch": "^7.4.3",
+				"mkdirp": "^2.1.6",
+				"path-browserify": "^1.0.1"
+			}
+		},
+		"node_modules/@ts-morph/common/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@ts-morph/common/node_modules/minimatch": {
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+			"integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@ts-morph/common/node_modules/mkdirp": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+			"integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+			"dev": true,
+			"bin": {
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@types/eslint": {
@@ -2180,6 +2232,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/code-block-writer": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+			"integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==",
+			"dev": true
 		},
 		"node_modules/code-excerpt": {
 			"version": "4.0.0",
@@ -6529,6 +6587,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true
+		},
 		"node_modules/path-exists": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -8085,6 +8149,16 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
+			}
+		},
+		"node_modules/ts-morph": {
+			"version": "19.0.0",
+			"resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-19.0.0.tgz",
+			"integrity": "sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==",
+			"dev": true,
+			"dependencies": {
+				"@ts-morph/common": "~0.20.0",
+				"code-block-writer": "^12.0.0"
 			}
 		},
 		"node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"strip-indent": "^4.0.0",
 		"svelte": "^4.1.2",
 		"svelte-check": "^3.4.6",
+		"ts-morph": "^19.0.0",
 		"typescript": "^5.1.6",
 		"vite": "^4.4.7",
 		"xo": "^0.55.0"


### PR DESCRIPTION
For https://github.com/refined-github/github-url-detection/issues/146

I found a package that allows extraction of URL from JSDoc. The issue is that we sometimes have comments around test URLs, which are impractical in JSDoc:

- while they can be easily filtered out, any deviations from the expected comment position would require future changes to this setup

but mainly:

- JSDoc are user-facing while these comments might not make sense outside the source code, e.g.


```
/** 
 * Some of these are here simply as "gotchas" to other detections
 * @example https://github.com/sindresorhus/refined-github/blame/master/package.json // Gotcha for isRepoTaxonomyIssueOrPRList
 * @example https://github.com/sindresorhus/notifications/
 */
```

this would show up as the description of the `isRepo` function, which is not relevant to the final user.