### PR TITLE
Add `isFile404`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -528,6 +528,12 @@ addTests('isFileFinder', [
 	'https://github.com/sindresorhus/refined-github/find/master',
 ]);
 
+/**
+ * @example https://github.com/fregante/GhostText/tree/3cacd7df71b097dc525d99c7aa2f54d31b02fcc8/chrome/scripts/InputArea
+ * @example https://github.com/refined-github/refined-github/blob/some-non-existent-ref/source/features/bugs-tab.tsx
+ */
+export const isRepoFile404 = (url: URL | HTMLAnchorElement | Location = location): boolean => (isSingleFile(url) || isRepoTree(url)) && document.title.startsWith('File not found');
+
 export const isRepoForksList = (url: URL | HTMLAnchorElement | Location = location): boolean => getRepo(url)?.path === 'network/members';
 addTests('isRepoForksList', [
 	'https://github.com/sindresorhus/refined-github/network/members',

--- a/test.ts
+++ b/test.ts
@@ -129,6 +129,16 @@ test('isPRFile404', t => {
 	t.false(pageDetect.isPRFile404());
 });
 
+test('isRepoFile404', t => {
+	document.title = 'File not found';
+	location.href = 'https://github.com/fregante/GhostText/tree/3cacd7df71b097dc525d99c7aa2f54d31b02fcc8/chrome/scripts/InputArea';
+	t.true(pageDetect.isRepoFile404());
+
+	document.title = 'File not found';
+	location.href = 'https://github.com/refined-github/refined-github/blob/some-non-existent-ref/source/features/bugs-tab.tsx';
+	t.true(pageDetect.isRepoFile404());
+});
+
 const {getRepositoryInfo} = pageDetect.utils;
 test('getRepositoryInfo', t => {
 	const inputTypes = [


### PR DESCRIPTION
## Description 
- `is404()` can not detecting new 404 pages
  - https://github.com/fregante/GhostText/tree/3cacd7df71b097dc525d99c7aa2f54d31b02fcc8/chrome/scripts/InputArea
  - https://github.com/refined-github/refined-github/blob/some-non-existent-ref/source/features/bugs-tab.tsx
- related: 
  - https://github.com/refined-github/refined-github/issues/6413