### PR TITLE
Add `isLoggedIn`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,8 @@ export const is500 = (): boolean => document.title === 'Server Error · GitHub' 
 
 export const isPasswordConfirmation = (): boolean => document.title === 'Confirm password' || document.title === 'Confirm access';
 
+export const isLoggedIn = (): boolean => exists('body.logged-in');
+
 export const isBlame = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('blame/'));
 addTests('isBlame', [
 	'https://github.com/sindresorhus/refined-github/blame/master/package.json',


### PR DESCRIPTION
Refined GitHub does not support logged out users, but a couple of features are troublesome (e.g. `locked-issue` will mark all issues as locked when logged out) so this check can be useful.