### PR TITLE
Refactor conversation state detections

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -286,38 +286,20 @@ TEST: addTests('isQuickPR', [
 	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1',
 ]);
 
-const stateSelector = [
-	'.State',
-	'[data-testid="header-state"]',
-].join(',');
+const getStateLabel = (): string | undefined => $([
+	'.State', // Old view
+	'[class^="StateLabel"]', // React version
+].join(','))?.textContent?.trim();
 
-export const isDraftPR = (): boolean => $(stateSelector)?.textContent!.trim() === 'Draft';
-export const isOpenPR = (): boolean => {
-	if (!isPR()) {
-		return false;
-	}
-
-	const status = $(stateSelector)!.textContent!.trim();
+export const isMergedPR = (): boolean => getStateLabel() === 'Merged';
+export const isDraftPR = (): boolean => getStateLabel() === 'Draft';
+export const isOpenConversation = (): boolean => {
+	const status = getStateLabel();
 	return status === 'Open' || status === 'Draft';
 };
 
-export const isMergedPR = (): boolean => $(stateSelector)?.textContent!.trim() === 'Merged';
-
-export const isClosedPR = (): boolean => {
-	if (!isPR()) {
-		return false;
-	}
-
-	const status = $(stateSelector)!.textContent!.trim();
-	return status === 'Closed' || status === 'Merged';
-};
-
-export const isClosedIssue = (): boolean => {
-	if (!isIssue()) {
-		return false;
-	}
-
-	const status = $(stateSelector)!.textContent!.trim();
+export const isClosedConversation = (): boolean => {
+	const status = getStateLabel();
 	return status === 'Closed' || status === 'Closed as not planned';
 };
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"build:esbuild": "esbuild index.ts --bundle --external:github-reserved-names --outdir=distribution --format=esm --drop-labels=TEST",
 		"build:typescript": "tsc --declaration --emitDeclarationOnly",
 		"build:demo": "vite build demo",
+		"fix": "xo --fix",
 		"prepack": "npm run build",
 		"test": "run-p build test:* xo",
 		"test:unit": "vitest",


### PR DESCRIPTION
Drops:

- isClosedPR
- isClosedIssue
- isOpenPR

No need to be that specific. These checks are best used together with more specific checks, like `isPR` or `isPRFiles`, they don't need to be super specific.

Also fixes https://github.com/refined-github/github-url-detection/pull/201/files#r1835622282