### PR TITLE
`isQuickPR` - Support 'expand' query parameter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -52,9 +52,7 @@ TEST: addTests('isCompare', [
 	'https://github.com/sindresorhus/refined-github/compare',
 	'https://github.com/sindresorhus/refined-github/compare/',
 	'https://github.com/sindresorhus/refined-github/compare/master...branch-name',
-	'https://github.com/sindresorhus/refined-github/compare/master...branch-name?quick_pull=1',
-	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2?quick_pull=1',
-	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1',
+	'isQuickPR',
 ]);
 
 export const isCompareWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && getCleanPathname(url).split('/').slice(3, 5).includes('_compare');
@@ -293,6 +291,7 @@ TEST: addTests('isQuickPR', [
 	'https://github.com/sindresorhus/refined-github/compare/master...branch-name?quick_pull=1',
 	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2?quick_pull=1',
 	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1',
+	'https://github.com/refined-github/sandbox/compare/fregante-patch-2?expand=1',
 	'https://github.com/refined-github/sandbox/compare/default-a...fregante-patch-2?expand=1',
 ]);
 


### PR DESCRIPTION
https://github.com/refined-github/sandbox/tree/fregante-patch-2 -> contribute -> open pull request

`quick_pull=1` still works, though

used by `linkify-branch-references`