### PR TITLE
Fix state detections on updated PR conversation page

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -296,10 +296,10 @@ TEST: addTests('isQuickPR', [
 ]);
 
 const getStateLabel = (): string | undefined => $([
-	'.State', // Old view
-	// React versions
-	'[class^="StateLabel"]', // TODO: Remove after July 2026
 	'[class^="prc-StateLabel-StateLabel"]',
+	// TODO: Remove after July 2026
+	'[class^="StateLabel"]',
+	'.State',
 ].join(','))?.textContent?.trim();
 
 export const isMergedPR = (): boolean => getStateLabel() === 'Merged';


### PR DESCRIPTION
If we place the `.State` selector first, it's possible that we select a badge from the events timeline

Test URL: https://github.com/refined-github/sandbox/pull/124