### PR TITLE
Deprecate `isRepoFile404`

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -134,16 +134,6 @@ test('isPRFile404', () => {
 	assert.equal(pageDetect.isPRFile404(), false);
 });
 
-test('isRepoFile404', () => {
-	document.title = 'File not found';
-	location.href = 'https://github.com/fregante/GhostText/tree/3cacd7df71b097dc525d99c7aa2f54d31b02fcc8/chrome/scripts/InputArea';
-	assert.ok(pageDetect.isRepoFile404());
-
-	document.title = 'File not found';
-	location.href = 'https://github.com/refined-github/refined-github/blob/some-non-existent-ref/source/features/bugs-tab.tsx';
-	assert.ok(pageDetect.isRepoFile404());
-});
-
 const {getRepositoryInfo} = pageDetect.utils;
 test('getRepositoryInfo', () => {
 	const inputTypes = [

--- a/index.ts
+++ b/index.ts
@@ -748,6 +748,7 @@ TEST: addTests('isFileFinder', [
 ]);
 
 /**
+ * @deprecated Use is404 and isSingleFile/isRepoTree directly
  * @example https://github.com/fregante/GhostText/tree/3cacd7df71b097dc525d99c7aa2f54d31b02fcc8/chrome/scripts/InputArea
  * @example https://github.com/refined-github/refined-github/blob/some-non-existent-ref/source/features/bugs-tab.tsx
  */


### PR DESCRIPTION
Overly specific and incorrect: it takes a URL and then it reads the global state 🤷‍♂️ 

The reason was originally https://github.com/refined-github/github-url-detection/pull/183#issuecomment-1679095156 but the very recent https://github.com/refined-github/refined-github/pull/9603 removed the need for such specific checks.