### PR TITLE
`isRepoIssueList` - Test for `issues/views` 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -553,6 +553,7 @@ TEST: addTests('isRepoIssueList', [
 	'https://github.com/sindresorhus/refined-github/issues',
 	'https://github.com/sindresorhus/refined-github/issues/fregante',
 	'https://github.com/sindresorhus/refined-github/issues/newton',
+	'https://github.com/refined-github/refined-github/issues/views/4537',
 	'https://github.com/sindresorhus/refined-github/issues/wptemplates',
 	'https://github.com/sindresorhus/refined-github/issues?q=is%3Aclosed+sort%3Aupdated-desc',
 	'https://github.com/sindresorhus/refined-github/labels/bug',


### PR DESCRIPTION
## What

Adds coverage for repository issue-view URLs such as `/issues/views/4537`.

## Why

The existing `isRepoIssueList` rule already recognizes this GitHub URL format, but it was not protected by a regression test.

Closes #252.

## Validation

- `npm run test:unit -- --run` (18,156 tests passed)
- TypeScript validation passed
- Demo build passed

`npm test` reaches an existing XO/tsconfig configuration error for `add-examples-to-dts.ts`, unrelated to this one-line test addition.
